### PR TITLE
feat: add support for adding task in a section

### DIFF
--- a/background_scripts/background.js
+++ b/background_scripts/background.js
@@ -18,6 +18,7 @@ async function getProjects() {
 }
 
 const DUE_STRINGS = Object.freeze(["Today", "Tomorrow", "Next week"]);
+const NO_DUE = "No due date";
 
 async function setProjectMenus() {
   const contexts = ["selection", "link", "page"];
@@ -54,15 +55,15 @@ async function setProjectMenus() {
       DUE_STRINGS.forEach((dueString, dueIndex) => {
         browser.menus.create({
           contexts,
-          id: `${index}-due-${dueString}`,
+          id: `${id}-${dueString}`,
           title: `&${dueIndex + 1} ${dueString}`,
           parentId
         });
       });
       browser.menus.create({
         contexts,
-        id: `${index}-due`,
-        title: `&${DUE_STRINGS.length + 1} No due date`,
+        id: `${id}-${NO_DUE}`,
+        title: `&${DUE_STRINGS.length + 1} ${NO_DUE}`,
         parentId
       });
     });
@@ -133,9 +134,10 @@ async function saveTask(event) {
 
   if (content) {
     const projects = await getProjects();
-    const dueString = event.menuItemId.split("-").pop();
-    const { id: projectId, name: projectName } =
-      projects.find(({ id }) => id === event.parentMenuItemId) || {};
+    const idParts = event.menuItemId.split("-");
+    const projectId = idParts[0];
+    const dueString = idParts[1];
+    const { name: projectName } = projects.find(({ id }) => id === projectId) || {};
 
     const response = await fetch("https://api.todoist.com/rest/v2/tasks", {
       method: "post",
@@ -191,6 +193,6 @@ browser.commands.onCommand.addListener(async command => {
     const [pageUrl] = await browser.tabs.executeScript({
       code: "location.href"
     });
-    saveTask({ pageUrl, menuItemId: "0-Inbox", parentMenuItemId: inbox.id });
+    saveTask({ pageUrl, menuItemId: `${inbox.id}-${NO_DUE}`, parentMenuItemId: inbox.id });
   }
 });

--- a/background_scripts/background.js
+++ b/background_scripts/background.js
@@ -12,7 +12,7 @@ async function getApiKey() {
 async function getProjects() {
   const key = await getApiKey();
   const response = await fetch("https://api.todoist.com/rest/v2/projects", {
-    headers: { Authorization: `Bearer ${key}` }
+    headers: { Authorization: `Bearer ${key}` },
   });
   return response.json();
 }
@@ -20,9 +20,10 @@ async function getProjects() {
 const DUE_STRINGS = Object.freeze(["Today", "Tomorrow", "Next week"]);
 
 async function setProjectMenus() {
+  const contexts = ["selection", "link", "page"];
   const projects = await getProjects();
   const inbox = projects.find(project => project.is_inbox_project === true);
-  const contexts = ["selection", "link", "page"];
+  inbox.order = -1;
 
   browser.menus.create({
     contexts,


### PR DESCRIPTION
This PR makes it possible to add a task directly to a section in a project, instead of just adding it to a project without a section.

To do this, I also slightly rewrote how menu item IDs are handled: they are now always `${projectId}-${dueDate}` or `${projectId}-${dueDate}-${sectionId}`.

---
Quick disclaimers:
- I'm not a JS dev, I hope I didn't do anything stupid 😅
- Only tested in Firefox
- I work for Doist on the Todoist Backend, but this work isn't supported or endorsed by Doist.